### PR TITLE
priceDecimals is required in the TradeChart component

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ import '@wangleiddex/hydro-sdk-charts/dist/style.css';
   theme="dark" // or light
   data={testData}
   granularityStr="1d"
+  priceDecimals={4}
   styles={{ upColor: '#00d99f' }}
   clickCallback={result => {
     console.log('result: ', result);


### PR DESCRIPTION
If this is left out the following error is thrown: `Error: invalid format: .undefinedf`

This is due to the format function used [here](https://github.com/HydroProtocol/hydro-sdk-charts/blob/master/src/TradeChart/index.tsx#L377) and the rest of the file where it is looking for `priceDecimals` in the `format` function.